### PR TITLE
Allow custom page model for modules

### DIFF
--- a/lib/module.php
+++ b/lib/module.php
@@ -5,6 +5,7 @@ namespace Kirby\Modules;
 // Kirby dependencies
 use Obj;
 use Tpl;
+use Page;
 
 /**
  * Module
@@ -50,10 +51,15 @@ class Module extends Obj {
 	 */
 	public function register() {
 		$kirby = kirby();
-		
-		$kirby->set('blueprint',   $this->template(), $this->blueprintFile());
-		$kirby->set('page::model', $this->template(), 'kirby\\modules\\modulepage');
-		$kirby->set('template',    $this->template(), dirname(__DIR__) . DS . 'etc' . DS . 'template.php');
+		$template = $this->template();
+
+		$kirby->set('blueprint',   $template, $this->blueprintFile());
+		$kirby->set('template',    $template, dirname(__DIR__) . DS . 'etc' . DS . 'template.php');
+
+		// Load user defined Page model in case one exists
+		if (!array_key_exists($template, page::$models)) {
+			$kirby->set('page::model', $template, 'kirby\\modules\\modulepage');
+		}
 	}
 	
 	/**

--- a/lib/module.php
+++ b/lib/module.php
@@ -56,7 +56,7 @@ class Module extends Obj {
 		$kirby->set('blueprint', $template, $this->blueprintFile());
 		$kirby->set('template',  $template, dirname(__DIR__) . DS . 'etc' . DS . 'template.php');
 
-		// Load user defined Page model in case one exists
+		// Load custom Page model in case one exists
 		if (!array_key_exists($template, page::$models)) {
 			$kirby->set('page::model', $template, 'kirby\\modules\\modulepage');
 		}

--- a/lib/module.php
+++ b/lib/module.php
@@ -53,8 +53,8 @@ class Module extends Obj {
 		$kirby = kirby();
 		$template = $this->template();
 
-		$kirby->set('blueprint',   $template, $this->blueprintFile());
-		$kirby->set('template',    $template, dirname(__DIR__) . DS . 'etc' . DS . 'template.php');
+		$kirby->set('blueprint', $template, $this->blueprintFile());
+		$kirby->set('template',  $template, dirname(__DIR__) . DS . 'etc' . DS . 'template.php');
 
 		// Load user defined Page model in case one exists
 		if (!array_key_exists($template, page::$models)) {


### PR DESCRIPTION
I needed custom page model for a few modules and came up with this solution.

```php
<?php // model/module.link.php

use Kirby\Modules\Modulepage;

class Modulelinkpage extends Modulepage
{
    public function url()
    {
        return $this->link();
    }
}
```

A note needs to be added to the docs stating that the module model needs to extend `Kirby\Modules\Modulepage` instead of `Page`.